### PR TITLE
Add MemBrain-seg functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Make sure to pick the correct environment as kernel to have access to the instal
 
 When loading a new file it is advised to either restart the kernel and start from the top of the notebook. Or at least re-run the file loading cell. This will purge any existing data and avoid potential issues in the experimental stage.
 
+
+## MemBrain-seg installation
+If you would like to use [MemBrain-seg](https://github.com/teamtomo/membrain-seg/) to create initial membrane segmentations, you can install it to your environment via
+
+```
+git clone https://github.com/teamtomo/membrain-seg.git
+cd membrain-seg
+pip install .
+```
+
+or refer to MemBrain-seg's [installation instructions](https://github.com/teamtomo/membrain-seg/blob/main/docs/installation.md).
+
 ## Detailed User Guide:
 Detailed tutorial and user guide can be found in the ```colabseg_use_guide.pdf```.
 

--- a/colabseg/membrainseg_wrapper.py
+++ b/colabseg/membrainseg_wrapper.py
@@ -1,0 +1,120 @@
+#
+# ColabSeg - Interactive segmentation GUI
+#
+# Marc Siggel, December 2021
+# Adapted by Lorenz Lamm for MemBrain-seg, July 2023
+
+import os
+from ipywidgets import widgets
+from ipywidgets import Layout
+
+from membrain_seg.segmentation.segment import segment as membrain_segment
+from membrain_seg.tomo_preprocessing.pixel_size_matching.match_pixel_size import match_pixel_size as membrain_match_pixel_size
+
+
+def generate_membrainseg_gui():
+    """Generates MemBrain-seg GUI"""
+    all_values = {}
+
+    def run_tv_code(obj):
+        """This is a wrapper for MemBrain-seg"""
+        print("MemBrain-seg running on {}".format(all_values["tomo_file"].value))
+        if os.path.isfile(all_values["tomo_file"].value) is False:
+            raise ValueError("Tomogram doesn't exist!")
+        # if os.path.isfile(all_values["membrain_model"].value) is False:
+        #     raise ValueError("MemBrain model doesn't exist!")
+
+        if all_values["rescale_tomo"].value:
+            print("Rescaling your tomogram. This can take several minutes.")
+            px_scale_out = os.path.splitext(os.path.basename(all_values["tomo_file"].value))[0] + "_px_scaled.mrc"
+            membrain_match_pixel_size(
+                input_tomogram=all_values["tomo_file"].value,
+                output_path=px_scale_out,
+                pixel_size_in=(None if all_values["input_px"].value == "" else float(all_values["input_px"].value)),
+                pixel_size_out=float(all_values["output_px"].value),
+                disable_smooth=False
+            )
+
+        base_name = os.path.splitext(all_values["tomo_file"].value)[0]
+        print("Segmenting your tomogram using MemBrain-seg.")
+        out_file_seg = membrain_segment(
+            tomogram_path=all_values["tomo_file"].value,
+            ckpt_path=all_values["membrain_model"].value,
+            out_folder=os.getcwd()
+        )
+
+        if all_values["remove_intermediates"].value:
+            os.remove(px_scale_out)
+        print("Your file is written to", out_file_seg)
+
+
+    box_layout = Layout(display='flex',
+                    flex_flow='row',
+                    align_items='stretch',
+                    width='800px') 
+
+    all_values["membrain_model"] = widgets.Text(
+    placeholder='PATH/TO/MEMBRAIN_MODEL',
+    description='MemBrain-seg model:',
+    style = {'description_width': 'initial'},
+    layout = box_layout,
+    disabled=False)
+
+    all_values["tomo_file"] = widgets.Text(
+    placeholder='input_tomo.mrc',
+    description='Input Filename:',
+    style = {'description_width': 'initial'},
+    layout = box_layout,
+    disabled=False)
+
+
+    all_values["rescale_tomo"] = widgets.Checkbox(
+    value=False,
+    description='Rescale tomogram?',
+    style = {'description_width': 'initial'},
+    layout = widgets.Layout(width='200px'))
+
+
+    all_values["input_px"] = widgets.Text(
+    placeholder='default',
+    description='pixel size of tomogram (if not specified, pixel size is read from header.)',
+    style = {'description_width': 'initial'},
+    layout = box_layout,
+    disabled=False)
+
+    all_values["output_px"] = widgets.Text(
+    value="10.0",
+    placeholder='10.0',
+    description='target pixel size of tomogram. (i.e. to which pixel size should tomogram be scaled?)',
+    style = {'description_width': 'initial'},
+    layout = box_layout,
+    disabled=False)
+
+    all_values["remove_intermediates"] = widgets.Checkbox(
+    value=False,
+    description='Remove Intermediates (px matching)',
+    style = {'description_width': 'initial'},
+    layout = widgets.Layout(width='200px'))
+
+    hbox_ckpt_path = all_values["membrain_model"]
+    hbox_tomo_file =  all_values["tomo_file"]
+    rescale_tomo = all_values["rescale_tomo"]
+    input_px = all_values["input_px"]
+    output_px = all_values["output_px"]
+    remove_intermediates = all_values["remove_intermediates"]
+
+    vbox_all = widgets.VBox([
+        hbox_ckpt_path,
+        hbox_tomo_file,
+        rescale_tomo,
+        remove_intermediates,
+        input_px,
+        output_px,
+        ])
+    #hbox = widgets.HBox([all_values["cpus"], all_values["sspace"]])
+    display(vbox_all)
+
+    start_run = widgets.Button(description="Run MemBrain-seg")
+    start_run.on_click(run_tv_code)
+    display(start_run)
+

--- a/colabseg/membrainseg_wrapper.py
+++ b/colabseg/membrainseg_wrapper.py
@@ -9,42 +9,28 @@ from ipywidgets import widgets
 from ipywidgets import Layout
 
 from membrain_seg.segmentation.segment import segment as membrain_segment
-from membrain_seg.tomo_preprocessing.pixel_size_matching.match_pixel_size import match_pixel_size as membrain_match_pixel_size
 
 
 def generate_membrainseg_gui():
     """Generates MemBrain-seg GUI"""
     all_values = {}
 
-    def run_tv_code(obj):
+    def run_membrain_code(obj):
         """This is a wrapper for MemBrain-seg"""
         print("MemBrain-seg running on {}".format(all_values["tomo_file"].value))
         if os.path.isfile(all_values["tomo_file"].value) is False:
             raise ValueError("Tomogram doesn't exist!")
-        # if os.path.isfile(all_values["membrain_model"].value) is False:
-        #     raise ValueError("MemBrain model doesn't exist!")
 
-        if all_values["rescale_tomo"].value:
-            print("Rescaling your tomogram. This can take several minutes.")
-            px_scale_out = os.path.splitext(os.path.basename(all_values["tomo_file"].value))[0] + "_px_scaled.mrc"
-            membrain_match_pixel_size(
-                input_tomogram=all_values["tomo_file"].value,
-                output_path=px_scale_out,
-                pixel_size_in=(None if all_values["input_px"].value == "" else float(all_values["input_px"].value)),
-                pixel_size_out=float(all_values["output_px"].value),
-                disable_smooth=False
-            )
-
-        base_name = os.path.splitext(all_values["tomo_file"].value)[0]
         print("Segmenting your tomogram using MemBrain-seg.")
         out_file_seg = membrain_segment(
             tomogram_path=all_values["tomo_file"].value,
             ckpt_path=all_values["membrain_model"].value,
-            out_folder=os.getcwd()
+            out_folder=os.getcwd(),
+            store_connected_components=all_values["compute_connected_components"].value,
+            connected_component_thres=(None if all_values["connected_component_thres"].value == "" else float(all_values["connected_component_thres"].value)),
+            test_time_augmentation=all_values["test_time_augmentation"].value
         )
 
-        if all_values["remove_intermediates"].value:
-            os.remove(px_scale_out)
         print("Your file is written to", out_file_seg)
 
 
@@ -67,54 +53,41 @@ def generate_membrainseg_gui():
     layout = box_layout,
     disabled=False)
 
-
-    all_values["rescale_tomo"] = widgets.Checkbox(
+    all_values["compute_connected_components"] = widgets.Checkbox(
     value=False,
-    description='Rescale tomogram?',
+    description='Should connected components be computed to separate membranes?',
     style = {'description_width': 'initial'},
-    layout = widgets.Layout(width='200px'))
+    layout = widgets.Layout(width='300px'))
 
-
-    all_values["input_px"] = widgets.Text(
-    placeholder='default',
-    description='pixel size of tomogram (if not specified, pixel size is read from header.)',
+    all_values["connected_component_thres"] = widgets.Text(
+    placeholder='0',
+    description='Connected components smaller than this will be removed.',
     style = {'description_width': 'initial'},
     layout = box_layout,
     disabled=False)
 
-    all_values["output_px"] = widgets.Text(
-    value="10.0",
-    placeholder='10.0',
-    description='target pixel size of tomogram. (i.e. to which pixel size should tomogram be scaled?)',
-    style = {'description_width': 'initial'},
-    layout = box_layout,
-    disabled=False)
-
-    all_values["remove_intermediates"] = widgets.Checkbox(
+    all_values["test_time_augmentation"] = widgets.Checkbox(
     value=False,
-    description='Remove Intermediates (px matching)',
+    description='Should 8-fold test-time augmentation be performed (takes longer)?',
     style = {'description_width': 'initial'},
-    layout = widgets.Layout(width='200px'))
+    layout = widgets.Layout(width='300px'))
 
     hbox_ckpt_path = all_values["membrain_model"]
     hbox_tomo_file =  all_values["tomo_file"]
-    rescale_tomo = all_values["rescale_tomo"]
-    input_px = all_values["input_px"]
-    output_px = all_values["output_px"]
-    remove_intermediates = all_values["remove_intermediates"]
+    conn_comp_pred =  all_values["compute_connected_components"]
+    conn_comp_thres =  all_values["connected_component_thres"]
+    test_time_aug =  all_values["test_time_augmentation"]
 
     vbox_all = widgets.VBox([
         hbox_ckpt_path,
         hbox_tomo_file,
-        rescale_tomo,
-        remove_intermediates,
-        input_px,
-        output_px,
+        conn_comp_pred,
+        conn_comp_thres,
+        test_time_aug
         ])
     #hbox = widgets.HBox([all_values["cpus"], all_values["sspace"]])
     display(vbox_all)
 
     start_run = widgets.Button(description="Run MemBrain-seg")
-    start_run.on_click(run_tv_code)
+    start_run.on_click(run_membrain_code)
     display(start_run)
-

--- a/colabseg/membrainseg_wrapper.py
+++ b/colabseg/membrainseg_wrapper.py
@@ -57,7 +57,7 @@ def generate_membrainseg_gui():
     value=False,
     description='Should connected components be computed to separate membranes?',
     style = {'description_width': 'initial'},
-    layout = widgets.Layout(width='300px'))
+    layout = widgets.Layout(width='800px'))
 
     all_values["connected_component_thres"] = widgets.Text(
     placeholder='0',
@@ -70,7 +70,7 @@ def generate_membrainseg_gui():
     value=False,
     description='Should 8-fold test-time augmentation be performed (takes longer)?',
     style = {'description_width': 'initial'},
-    layout = widgets.Layout(width='300px'))
+    layout = widgets.Layout(width='800px'))
 
     hbox_ckpt_path = all_values["membrain_model"]
     hbox_tomo_file =  all_values["tomo_file"]

--- a/colabseg_demo_notebook.ipynb
+++ b/colabseg_demo_notebook.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "67516ef3",
    "metadata": {
     "scrolled": false
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "from colabseg.tensorvoting_wrapper import *\n",
-    "from colabseg.segmentation_gui import *\n",
+    "#from colabseg.segmentation_gui import *\n",
     "from colabseg.membrainseg_wrapper import generate_membrainseg_gui"
    ]
   },
@@ -56,43 +56,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "a322d0a9",
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'generate_membrainseg_gui' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[1], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mgenerate_membrainseg_gui\u001b[49m() \u001b[38;5;66;03m# run MemBrain-seg\u001b[39;00m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'generate_membrainseg_gui' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "generate_membrainseg_gui() # run MemBrain-seg"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "ee4163ad",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d6c6a92fbeca43609a205314d6111f41",
+       "model_id": "9413bb32da3546618ceb9af38209cbdf",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(Text(value='', description='TV Path:', placeholder='PATH/TO/TOMOSEG', style=DescriptionStyle(de…"
+       "VBox(children=(Text(value='', description='MemBrain-seg model:', layout=Layout(align_items='stretch', display=…"
       ]
      },
      "metadata": {},
@@ -101,7 +77,48 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1dc230a024f244cfa6c82a1151631ecc",
+       "model_id": "f4ce70670b52475d8ed82bfd3821ed3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Run MemBrain-seg', style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "generate_membrainseg_gui() # run MemBrain-seg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ee4163ad",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0cc79c755f1348fa8653ece5c45de847",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Text(value='', description='TV Path:', placeholder='PATH/TO/TOMOSEG', style=TextStyle(descripti…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "10002d462622410d9e05060633c5e138",
        "version_major": 2,
        "version_minor": 0
       },
@@ -115,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "29d6c1b7c3e84fcfa2527b6f26f4cfa3",
+       "model_id": "a0eb0176898147b88921b069213691e9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -456,7 +473,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.0 ('ColabMemBrain')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/colabseg_demo_notebook.ipynb
+++ b/colabseg_demo_notebook.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "from colabseg.tensorvoting_wrapper import *\n",
-    "#from colabseg.segmentation_gui import *\n",
+    "from colabseg.segmentation_gui import *\n",
     "from colabseg.membrainseg_wrapper import generate_membrainseg_gui"
    ]
   },
@@ -30,67 +30,6 @@
     "# 1) Tensor Voting / MemBrain-seg\n",
     "\n",
     "Run one of the following cells to perform either TomoSegMemTV or MemBrain-seg to segment the membranes in your tomogram:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "8c9ff303",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'generate_tensor_voting_gui' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mgenerate_tensor_voting_gui\u001b[49m() \u001b[38;5;66;03m# run TomoSegMemTV\u001b[39;00m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'generate_tensor_voting_gui' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "generate_tensor_voting_gui() # run TomoSegMemTV"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "a322d0a9",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9413bb32da3546618ceb9af38209cbdf",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(Text(value='', description='MemBrain-seg model:', layout=Layout(align_items='stretch', display=…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f4ce70670b52475d8ed82bfd3821ed3e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(description='Run MemBrain-seg', style=ButtonStyle())"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "generate_membrainseg_gui() # run MemBrain-seg"
    ]
   },
   {
@@ -145,7 +84,46 @@
     }
    ],
    "source": [
-    "generate_tensor_voting_gui()"
+    "generate_tensor_voting_gui() # run TomoSegMemTV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a322d0a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9413bb32da3546618ceb9af38209cbdf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Text(value='', description='MemBrain-seg model:', layout=Layout(align_items='stretch', display=…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f4ce70670b52475d8ed82bfd3821ed3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Run MemBrain-seg', style=ButtonStyle())"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "generate_membrainseg_gui() # run MemBrain-seg"
    ]
   },
   {

--- a/colabseg_demo_notebook.ipynb
+++ b/colabseg_demo_notebook.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "67516ef3",
    "metadata": {
     "scrolled": false
@@ -18,7 +18,8 @@
    "outputs": [],
    "source": [
     "from colabseg.tensorvoting_wrapper import *\n",
-    "from colabseg.segmentation_gui import *"
+    "from colabseg.segmentation_gui import *\n",
+    "from colabseg.membrainseg_wrapper import generate_membrainseg_gui"
    ]
   },
   {
@@ -26,41 +27,53 @@
    "id": "366aa3c7",
    "metadata": {},
    "source": [
-    "# 1) Tensor Voting"
+    "# 1) Tensor Voting / MemBrain-seg\n",
+    "\n",
+    "Run one of the following cells to perform either TomoSegMemTV or MemBrain-seg to segment the membranes in your tomogram:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "16e58d80",
-   "metadata": {
-    "scrolled": false
-   },
+   "execution_count": 2,
+   "id": "8c9ff303",
+   "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "013_sq_df_sorted_binned.mrc             028_sq_df_sorted_binned_global2.mrc\r\n",
-      "013_sq_df_sorted_binned_global2.mrc     028_sq_df_sorted_binned_global2.mrc.gz\r\n",
-      "013_sq_df_sorted_binned_sspace.mrc      028_sq_df_sorted_global2.mrc\r\n",
-      "013_sq_df_sorted_binned_surf1.mrc       031_sq_df_sorted_binned.mrc\r\n",
-      "013_sq_df_sorted_binned_surf2.mrc       031_sq_df_sorted_binned_global2.mrc\r\n",
-      "013_sq_df_sorted_binned_thresh.mrc      031_sq_df_sorted_binned_thresh.mrc\r\n",
-      "013_sq_df_sorted_binned_tv1.mrc         PP_04_sorted_binned.mrc\r\n",
-      "013_sq_df_sorted_binned_tv2.mrc         PP_04_sorted_global2.mrc\r\n",
-      "013_sq_df_sorted_global2.mrc            PP_09_sorted_binned.mrc\r\n",
-      "024_conservative.mrc                    PP_09_sorted_binned_global2.mrc\r\n",
-      "024_sq_df_sorted_binned.mrc             PP_09_sorted_global2.mrc\r\n",
-      "024_sq_df_sorted_binned_global2.mrc     raw_tomograms_manual.txt\r\n",
-      "024_sq_df_sorted_binned_surf2.mrc       \u001b[1m\u001b[32mrun_tensorvoting_grotjahn.sh\u001b[m\u001b[m*\r\n",
-      "024_sq_df_sorted_binned_thresh.mrc      seg_tomograms_manual.txt\r\n",
-      "028_sq_df_sorted_binned.mrc\r\n"
+     "ename": "NameError",
+     "evalue": "name 'generate_tensor_voting_gui' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mgenerate_tensor_voting_gui\u001b[49m() \u001b[38;5;66;03m# run TomoSegMemTV\u001b[39;00m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'generate_tensor_voting_gui' is not defined"
      ]
     }
    ],
    "source": [
-    "ls"
+    "generate_tensor_voting_gui() # run TomoSegMemTV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a322d0a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'generate_membrainseg_gui' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[1], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mgenerate_membrainseg_gui\u001b[49m() \u001b[38;5;66;03m# run MemBrain-seg\u001b[39;00m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'generate_membrainseg_gui' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "generate_membrainseg_gui() # run MemBrain-seg"
    ]
   },
   {
@@ -443,9 +456,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "seg_test",
+   "display_name": "Python 3.8.0 ('ColabMemBrain')",
    "language": "python",
-   "name": "seg_test"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -457,7 +470,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.0"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "95c7c9545523fc50781ffbf487604435d61e4fb7ad5616715707e2a9e662aeb6"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds the MemBrain-seg functionality in the form of a membrainseg wrapper that can be called in the Jupyter Notebook instead of the TomoSegMemTV wrapper.
I also adjusted the example Jupyter notebook to include both TomoSegMemTV and MemBrain-seg as options, but maybe it's better to have a separate notebook for it?

Installation of MemBrain-seg and ColabSeg should be compatible. I followed the ColabSeg conda installation instructions, and in addition performed
`git clone https://github.com/teamtomo/membrain-seg.git`
`cd membrain_seg`
`pip install .`
Maybe this could be added to the installation instructions or simply a link to our installation documentation?
https://github.com/teamtomo/membrain-seg/blob/main/docs/installation.md


Let me know what you think / what can be improved :)